### PR TITLE
Utils to get and set mpl style

### DIFF
--- a/spirograph/matplotlib/utils.py
+++ b/spirograph/matplotlib/utils.py
@@ -535,13 +535,17 @@ def get_mpl_styles():
 
     return styles
 
-def set_mpl_style(*args):
+def set_mpl_style(*args, reset=False):
     """ Set the matplotlib style using one or more stylesheets.
     Parameters
     _________
     *args: str
         Name(s) of spirograph matplotlib style ('ouranos', 'paper, 'poster') or path(s) to matplotlib stylesheet(s).
+    reset: bool
+        Reset style to matplotlib default before applying the stylesheets.
     """
+    if reset is True:
+        mpl.style.use('default')
     for style in args:
         if style.endswith('.mplstyle') is True:
             mpl.style.use(style)


### PR DESCRIPTION
get_mpl_styles returns a tuple with a list of the style names and a list of their paths. set_mpl_style takes names and sets the style accordingly.