### PR TITLE
Format/pep8

### DIFF
--- a/spirograph/matplotlib/plot.py
+++ b/spirograph/matplotlib/plot.py
@@ -44,15 +44,17 @@ def _plot_realizations(
 
     Parameters
     ----------
-    ax: matplotlib.axes.Axes
+    ax : matplotlib.axes.Axes
         The Matplotlib axis object.
-    da: DataArray
+    da : DataArray
         The DataArray containing the realizations.
-    name: str
+    name : str
         The label to be used in the first part of a composite label.
         Can be the name of the parent Dataset or that of the DataArray.
-    plot_kw: dict
+    plot_kw : dict
         Dictionary of kwargs coming from the timeseries() input.
+    non_dict_data : dict
+        TBD.
 
     Returns
     -------
@@ -93,23 +95,23 @@ def timeseries(
 
     Parameters
     ----------
-    data: dict or Dataset/DataArray
+    data : dict or Dataset/DataArray
         Input data to plot. It can be a DataArray, Dataset or a dictionary of DataArrays and/or Datasets.
-    ax: matplotlib.axes.Axes, optional
+    ax : matplotlib.axes.Axes, optional
         Matplotlib axis on which to plot.
-    use_attrs: dict, optional
+    use_attrs : dict, optional
         A dict linking a plot element (key, e.g. 'title') to a DataArray attribute (value, e.g. 'Description').
         Default value is {'title': 'description', 'ylabel': 'long_name', 'yunits': 'units'}.
         Only the keys found in the default dict can be used.
-    fig_kw: dict, optional
+    fig_kw : dict, optional
         Arguments to pass to `plt.subplots()`. Only works if `ax` is not provided.
-    plot_kw: dict, optional
+    plot_kw : dict, optional
         Arguments to pass to the `plot()` function. Changes how the line looks.
         If 'data' is a dictionary, must be a nested dictionary with the same keys as 'data'.
-    legend: str (default 'lines')
+    legend : str (default 'lines')
         'full' (lines and shading), 'lines' (lines only), 'in_plot' (end of lines),
          'edge' (out of plot), 'none' (no legend).
-    show_lat_lon: bool (default True)
+    show_lat_lon : bool (default True)
         If True, show latitude and longitude coordinates at the bottom right of the figure.
 
     Returns
@@ -345,43 +347,43 @@ def gridmap(
 
     Parameters
     ----------
-    data: dict, DataArray or Dataset
+    data : dict, DataArray or Dataset
         Input data do plot. If dictionary, must have only one entry.
-    ax: matplotlib axis, optional
+    ax : matplotlib axis, optional
         Matplotlib axis on which to plot, with the same projection as the one specified.
-    use_attrs: dict, optional
+    use_attrs : dict, optional
         Dict linking a plot element (key, e.g. 'title') to a DataArray attribute (value, e.g. 'Description').
         Default value is {'title': 'description', 'cbar_label': 'long_name', 'cbar_units': 'units'}.
         Only the keys found in the default dict can be used.
-    fig_kw: dict, optional
+    fig_kw : dict, optional
         Arguments to pass to `plt.figure()`.
-    plot_kw: dict, optional
+    plot_kw:  dict, optional
         Arguments to pass to the `xarray.plot.pcolormesh()` or 'xarray.plot.contourf()' function.
         If 'data' is a dictionary, can be a nested dictionary with the same keys as 'data'.
-    projection: ccrs projection
-        Projection to use, taken from the cartopy.crs options. Ignored if ax is not None.
-    transform: ccrs transform, optional
+    projection : ccrs.Projection
+        The projection to use, taken from the cartopy.crs options. Ignored if ax is not None.
+    transform : ccrs.Projection, optional
         Transform corresponding to the data coordinate system. If None, an attempt is made to find dimensions matching
         ccrs.PlateCarree() or ccrs.RotatedPole().
-    features: list or dict, optional
+    features : list or dict, optional
         Features to use, as a list or a nested dict containing kwargs. Options are the predefined features from
         cartopy.feature: ['coastline', 'borders', 'lakes', 'land', 'ocean', 'rivers'].
     geometries_kw : dict, optional
         Arguments passed to cartopy ax.add_geometry() which adds given geometries (GeoDataFrame geometry) to axis.
-    contourf: bool
+    contourf : bool
         By default False, use plt.pcolormesh(). If True, use plt.contourf().
-    cmap: colormap or str, optional
+    cmap : colormap or str, optional
         Colormap to use. If str, can be a matplotlib or name of the file of an IPCC colormap (see data/ipcc_colors).
         If None, look for common variables (from data/ipcc_colors/varaibles_groups.json) in the name of the DataArray
         or its 'history' attribute and use corresponding colormap, aligned with the IPCC visual style guide 2022
         (https://www.ipcc.ch/site/assets/uploads/2022/09/IPCC_AR6_WGI_VisualStyleGuide_2022.pdf).
-    levels: int, optional
+    levels : int, optional
         Levels to use to divide the colormap. Acceptable values are from 2 to 21, inclusive.
-    divergent: bool or int or float
+    divergent : bool or int or float
         If int or float, becomes center of cmap. Default center is 0.
-    show_time:bool
+    show_time : bool
         Show time (as date) at bottom right of plot.
-    frame: bool
+    frame : bool
         Show or hide frame. Default False.
 
     Returns

--- a/spirograph/matplotlib/utils.py
+++ b/spirograph/matplotlib/utils.py
@@ -33,7 +33,7 @@ def check_timeindex(xr_dict: dict[str, Any]) -> dict[str, Any]:
 
     Parameters
     ----------
-    xr_dict: dict
+    xr_dict : dict
         Dictionary containing Xarray DataArrays or Datasets.
 
     Returns
@@ -57,7 +57,7 @@ def get_array_categ(array: xr.DataArray | xr.Dataset) -> str:
 
     Parameters
     __________
-    array: Dataset or DataArray
+    array : Dataset or DataArray
         The array being categorized.
 
     Returns
@@ -114,9 +114,9 @@ def get_attributes(string: str, xr_obj: xr.DataArray | xr.Dataset) -> str:
 
     Parameters
     ----------
-    string: str
+    string : str
         String corresponding to an attribute name.
-    xr_obj: DataArray or Dataset
+    xr_obj : DataArray or Dataset
         The Xarray object containing the attributes.
 
     Returns
@@ -154,15 +154,15 @@ def set_plot_attrs(
 
     Parameters
     ----------
-    attr_dict: dict
+    attr_dict : dict
         Dictionary containing specified attribute keys.
-    xr_obj: Dataset or DataArray
+    xr_obj : Dataset or DataArray
         The Xarray object containing the attributes.
-    ax: matplotlib axis
+    ax : matplotlib axis
         The matplotlib axis of the plot.
-    title_loc: str
+    title_loc : str
         Location of the title.
-    wrap_kw: dict, optional
+    wrap_kw : dict, optional
         Arguments to pass to the wrap_text function for the title.
 
     Returns
@@ -220,7 +220,7 @@ def sort_lines(array_dict: dict[str, Any]) -> dict[str, str]:
 
     Parameters
     ----------
-    array_dict: dict
+    array_dict : dict
         Dictionary of format {'name': array...}.
 
     Returns
@@ -312,13 +312,13 @@ def split_legend(
 
     Parameters
     ----------
-    ax: matplotlib.axes.Axes
+    ax : matplotlib.axes.Axes
         The axis containing the legend.
-    in_plot: bool
+    in_plot : bool
         If True, prolong plot area to fit labels. If False, print labels outside of plot area. Default: False.
-    axis_factor: float
+    axis_factor : float
         If in_plot is True, fraction of the x-axis length to add at the far right of the plot. Default: 0.15.
-    label_gap: float
+    label_gap : float
         If in_plot is True, fraction of the x-axis length to add as a gap between line and label. Default: 0.02.
 
     Returns
@@ -377,7 +377,7 @@ def fill_between_label(
         Dictionary created by the sort_lines() function.
     name : str
         Key associated with the object being plotted in the 'data' argument of the timeseries() function.
-    array_categ: dict
+    array_categ : dict
         The categories of the array, as created by the get_array_categ function.
     legend : str
         Legend mode.
@@ -450,13 +450,13 @@ def create_cmap(
 
     Parameters
     ----------
-    var_group: str, optional
+    var_group : str, optional
         Variable group from IPCC scheme.
-    levels: int, optional
+    levels : int, optional
         Number of levels for discrete colormaps. Must be between 2 and 21, inclusive. If None, use continuous colormap.
-    divergent: bool or int, float
+    divergent : bool or int, float
         Diverging colormap. If False, use sequential colormap.
-    filename: str, optional
+    filename : str, optional
         Name of IPCC colormap file. If not None, 'var_group' and 'divergent' are not used.
 
     Returns
@@ -539,7 +539,7 @@ def get_rotpole(xr_obj: xr.DataArray | xr.Dataset) -> ccrs.RotatedPole | None:
 
     Parameters
     ----------
-    xr_obj: xr.DataArray or xr.Dataset
+    xr_obj : xr.DataArray or xr.Dataset
         The xarray object from which to look for the attributes.
 
     Returns
@@ -564,11 +564,11 @@ def wrap_text(text: str, min_line_len: int = 18, max_line_len: int = 30) -> str:
 
     Arguments
     ---------
-    text: str
+    text : str
         The text to wrap.
-    min_line_len: int
+    min_line_len : int
         Minimum length of each line.
-    max_line_len: int
+    max_line_len : int
         Maximum length of each line.
 
     Returns
@@ -693,9 +693,9 @@ def set_mpl_style(*args: str, reset: bool = False) -> None:
 
     Parameters
     ----------
-    args: str
+    args : str
         Name(s) of spirograph matplotlib style ('ouranos', 'paper, 'poster') or path(s) to matplotlib stylesheet(s).
-    reset: bool
+    reset : bool
         If True, reset style to matplotlib default before applying the stylesheets.
 
     Returns


### PR DESCRIPTION
Adressed (at least partially) most of the comments/suggestions in https://github.com/Ouranosinc/spirograph/pull/38, including:

- Removed variable names conflicting with built-in functions
- Specified `Exception` types
- Completed and formatted docstrings
- Replaced most instances of `if type(object) == type` to ` if isinstance(object, type)`
