### PR TITLE
Add customization example in docs notebook

### DIFF
--- a/docs/notebooks/spirograph_docs.ipynb
+++ b/docs/notebooks/spirograph_docs.ipynb
@@ -705,7 +705,7 @@
     "Plots created with Spirograph can be customized in two different ways:\n",
     "\n",
     "1. By using the built-in options through arguments (e.g. changing the type of legend with the `legend` arg).\n",
-    "2. By creating an object and using the Matplotlib methods on it (e.g. setting a new title with `ax.set_title()`).\n",
+    "2. By creating a Matplotlib Axes class and using its methods (e.g. setting a new title with `ax.set_title()`).\n",
     "\n",
     "Both of these types of customization are demonstrated below. In some cases, both methods can achieve the same result. "
    ]


### PR DESCRIPTION
Added a section describing how to customize plots, through arguments and through the `ax` object. Amongst other things, it demonstrates how to change a left-aligned title using the `loc` argument.