### PR TITLE
Prevent gridmap from modifying the features dict

### DIFF
--- a/spirograph/matplotlib/utils.py
+++ b/spirograph/matplotlib/utils.py
@@ -871,6 +871,7 @@ def add_cartopy_features(
             ax.add_feature(
                 getattr(cfeature, f.upper()).with_scale(scale), **features[f]
             )
+            features[f]["scale"] = scale  # put back
     return ax
 
 


### PR DESCRIPTION
We were using `pop` to handle the scale of features in `gridmap`, causing the dictionary to be modified outside the function. 

This seemes necessary, so I added a line to put the popped entries back in the dicionary.