### PR TITLE
Less defaults in gdfmap

### DIFF
--- a/spirograph/matplotlib/plot.py
+++ b/spirograph/matplotlib/plot.py
@@ -679,8 +679,9 @@ def gdfmap(
         fig, ax = plt.subplots(subplot_kw={"projection": projection}, **fig_kw)
         ax.set_aspect("equal")  # recommended by geopandas
 
-    # add features and defaults
-    add_cartopy_features(ax, features)
+    # add features
+    if features:
+        add_cartopy_features(ax, features)
 
     # colormap
     if isinstance(cmap, str):


### PR DESCRIPTION
- Removed the default features in `gdfmap`. I think this came from my old code, but it's not really instinctive (`gridmap` has no default) and we might not always want them. It's better to leave that control to the User.
- Fixed the default `projection` when `ax` is provided.

EDIT: This should fix #91.