### PR TITLE
fix get_rotpole

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 
     Fixes
     ^^^^^
-    * Rotated pole with a different name are now accepted. (:pull:`308`).
+    * `fg.utils.get_rotpole` now accept more general inputs. (:pull:`308`).
 
 .. _changes_0.4.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
     `Unreleased <https://github.com/Ouranosinc/figanos>`_ (latest)
     --------------------------------------------------------------
 
-    Contributors:
+    Contributors: Juliette Lavoie (:user:`juliettelavoie`)
 
     Changes
     ^^^^^^^
@@ -14,7 +14,7 @@ Changelog
 
     Fixes
     ^^^^^
-    * No change.
+    * Rotated pole with a different name are now accepted. (:pull:`308`).
 
 .. _changes_0.4.0:
 

--- a/docs/notebooks/figanos_multiplots.ipynb
+++ b/docs/notebooks/figanos_multiplots.ipynb
@@ -431,9 +431,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "figanos",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "figanos"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -445,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/figanos_multiplots.ipynb
+++ b/docs/notebooks/figanos_multiplots.ipynb
@@ -172,14 +172,12 @@
     "obs = xr.Dataset({\"tas\": tas})\n",
     "\n",
     "# plot\n",
-    "fg.scattermap(\n",
+    "ax = fg.scattermap(\n",
     "    obs,\n",
     "    transform=ccrs.PlateCarree(),\n",
     "    sizes=\"years\",\n",
     "    size_range=(25, 100),\n",
     "    plot_kw={\n",
-    "        \"xlim\": (-77, -69),\n",
-    "        \"ylim\": (43, 50),\n",
     "        \"col\": \"season\",\n",
     "    },\n",
     "    features={\n",
@@ -190,7 +188,8 @@
     "    },\n",
     "    fig_kw={\"figsize\": (7, 4)},\n",
     "    legend_kw={\"ncol\": 4, \"bbox_to_anchor\": (0.15, 0.05)},\n",
-    ")"
+    ")\n",
+    "ax.set_xlim((-77, -69), transform=ccrs.PlateCarree())"
    ]
   },
   {
@@ -433,9 +432,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "figanos",
    "language": "python",
-   "name": "python3"
+   "name": "figanos"
   },
   "language_info": {
    "codemirror_mode": {
@@ -447,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/figanos_multiplots.ipynb
+++ b/docs/notebooks/figanos_multiplots.ipynb
@@ -188,8 +188,7 @@
     "    },\n",
     "    fig_kw={\"figsize\": (7, 4)},\n",
     "    legend_kw={\"ncol\": 4, \"bbox_to_anchor\": (0.15, 0.05)},\n",
-    ")\n",
-    "ax.set_xlim((-77, -69), transform=ccrs.PlateCarree())"
+    ")"
    ]
   },
   {

--- a/docs/notebooks/figanos_multiplots.ipynb
+++ b/docs/notebooks/figanos_multiplots.ipynb
@@ -172,7 +172,7 @@
     "obs = xr.Dataset({\"tas\": tas})\n",
     "\n",
     "# plot\n",
-    "ax = fg.scattermap(\n",
+    "fg.scattermap(\n",
     "    obs,\n",
     "    transform=ccrs.PlateCarree(),\n",
     "    sizes=\"years\",\n",

--- a/src/figanos/matplotlib/plot.py
+++ b/src/figanos/matplotlib/plot.py
@@ -650,8 +650,7 @@ def gridmap(
         if "lat" in data.dims and "lon" in data.dims:
             transform = ccrs.PlateCarree()
         if "rlat" in data.dims and "rlon" in data.dims:
-            if hasattr(data, "rotated_pole"):
-                transform = get_rotpole(data)
+            transform = get_rotpole(data)
 
     # setup fig, ax
     if ax is None and ("row" not in plot_kw.keys() and "col" not in plot_kw.keys()):
@@ -1682,8 +1681,7 @@ def scattermap(
     # setup transform
     if transform is None:
         if "rlat" in data.dims and "rlon" in data.dims:
-            if hasattr(data, "rotated_pole"):
-                transform = get_rotpole(data)
+            transform = get_rotpole(data)
         elif (
             "lat" in data.coords and "lon" in data.coords
         ):  # need to work with station dims
@@ -2462,8 +2460,7 @@ def hatchmap(
         if "lat" in trdata.dims and "lon" in trdata.dims:
             transform = ccrs.PlateCarree()
         elif "rlat" in trdata.dims and "rlon" in trdata.dims:
-            if hasattr(list(plot_data.values())[0], "rotated_pole"):
-                transform = get_rotpole(list(plot_data.values())[0])
+            transform = get_rotpole(list(plot_data.values())[0])
 
     # bug xlim / ylim + transform in facetgrids
     # (see https://github.com/pydata/xarray/issues/8562#issuecomment-1865189766)

--- a/src/figanos/matplotlib/utils.py
+++ b/src/figanos/matplotlib/utils.py
@@ -970,7 +970,7 @@ def get_rotpole(xr_obj: xr.DataArray | xr.Dataset) -> ccrs.RotatedPole | None:
     try:
 
         if isinstance(xr_obj, xr.Dataset):
-            gridmap = xr_obj.cf.grid_mapping_names.get('rotated_latitude_longitude', [])
+            gridmap = xr_obj.cf.grid_mapping_names.get("rotated_latitude_longitude", [])
 
             if len(gridmap) > 1:
                 warnings.warn(

--- a/src/figanos/matplotlib/utils.py
+++ b/src/figanos/matplotlib/utils.py
@@ -970,16 +970,7 @@ def get_rotpole(xr_obj: xr.DataArray | xr.Dataset) -> ccrs.RotatedPole | None:
     try:
 
         if isinstance(xr_obj, xr.Dataset):
-            ds = xr_obj
-            gridmap = [
-                ds[v].attrs["grid_mapping"]
-                for v in ds.data_vars
-                if "grid_mapping" in ds[v].attrs
-            ]
-            gridmap += [
-                c for c in ds.coords if ds[c].attrs.get("grid_mapping_name", None)
-            ]
-            gridmap = list(np.unique(gridmap))
+            gridmap = xr_obj.cf.grid_mapping_names.get('rotated_latitude_longitude', [])
 
             if len(gridmap) > 1:
                 warnings.warn(

--- a/src/figanos/matplotlib/utils.py
+++ b/src/figanos/matplotlib/utils.py
@@ -968,10 +968,33 @@ def get_rotpole(xr_obj: xr.DataArray | xr.Dataset) -> ccrs.RotatedPole | None:
     ccrs.RotatedPole or None
     """
     try:
+
+        if isinstance(xr_obj, xr.Dataset):
+            ds = xr_obj
+            gridmap = [
+                ds[v].attrs["grid_mapping"]
+                for v in ds.data_vars
+                if "grid_mapping" in ds[v].attrs
+            ]
+            gridmap += [
+                c for c in ds.coords if ds[c].attrs.get("grid_mapping_name", None)
+            ]
+            gridmap = list(np.unique(gridmap))
+
+            if len(gridmap) > 1:
+                warnings.warn(
+                    f"There are conflicting grid_mapping attributes in the dataset. Assuming {gridmap[0]}."
+                )
+
+            coord_name = gridmap[0] if gridmap else "rotated_pole"
+        else:
+            # If it can't find grid_mapping, assume it's rotated_pole
+            coord_name = xr_obj.attrs.get("grid_mapping", "rotated_pole")
+
         rotpole = ccrs.RotatedPole(
-            pole_longitude=xr_obj.rotated_pole.grid_north_pole_longitude,
-            pole_latitude=xr_obj.rotated_pole.grid_north_pole_latitude,
-            central_rotated_longitude=xr_obj.rotated_pole.north_pole_grid_longitude,
+            pole_longitude=xr_obj[coord_name].grid_north_pole_longitude,
+            pole_latitude=xr_obj[coord_name].grid_north_pole_latitude,
+            central_rotated_longitude=xr_obj[coord_name].north_pole_grid_longitude,
         )
         return rotpole
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Instead of assuming the information for rotated pole is in `rotated_pole`, use the `grid_mapping` attrs to guess the name. Inspired by `xscen.spatial.get_grid_mapping`.
* small fix in the doc also

### Does this PR introduce a breaking change?
no

### Other information:
This is useful for the CRCM5 which uses the attr `crs`. It was decided in the Outils Communs meeting that we would change the code, not the data.

Note that another way to get this information is :

```
ds.cf.grid_mapping_names # Mapping grid mapping type -> [ nom_de_la_var ]
ds[DATAVAR].cf.grid_mapping_name  # Nom du type de grid mapping
# donc pour obtenir la variable contenant les informations
# sur le grid mapping de la variable DATAVAR: 
ds[ds.cf.grid_mapping_names[ds[DATAVAR].cf.grid_mapping_name][0]]
```
but this doesn't work if you only have a DataArray.

Is it worth it to add this also in the case where we have a ds without at `grid_mapping` attrs but the right cf.attrs ? Does that even happen ?