### PR TITLE
Drop Python3.9, update several dependency pins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          disable-sudo: true
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -143,15 +142,12 @@ jobs:
           python -m pip check || true
       - name: Test with pytest
         run: |
-          python -m pytest --cov figanos
+          python -m pytest --cov=figanos --cov-report=lcov
       - name: Report Coverage
-        run: |
-          python -m coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: run-conda-python${{ matrix.python-version }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_SERVICE_NAME: github
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: run-{{ matrix.python-version }}-conda
+          parallel: true
 
   finish:
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
+          disable-sudo: true
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -64,15 +65,15 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
-#          - "3.13"
+          - "3.13"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
+          disable-sudo: true
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -112,7 +113,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         python-version:
           - "3.10"
-          - "3.12"
+          - "3.13"
     defaults:
       run:
         shell: bash -l {0}
@@ -120,6 +121,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
+          disable-sudo: true
           egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,19 +2,22 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/Ouranosinc/figanos>`_ (latest)
-    --------------------------------------------------------------
+`Unreleased <https://github.com/Ouranosinc/figanos>`_ (latest)
+--------------------------------------------------------------
+Contributors: Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`).
 
-    Contributors: Juliette Lavoie (:user:`juliettelavoie`)
+Changes
+^^^^^^^
+* `figanos` now supports Python 3.13 and has dropped support for Python 3.9. (:pull:`322`).
+* Several base dependencies have been updated to more modern versions. (:pull:`322`):
+  * `numpy` has been updated to `>=1.25.0` (no longer pinned below `2.0.0`).
+  * `pint` has been updated to `>=0.18.0`.
+  * `scikit-image` has been updated to `>=0.21.0`.
+  * `xarray` has been updated to `>=2023.11.0`.
 
-    Changes
-    ^^^^^^^
-    * No change.
-
-    Fixes
-    ^^^^^
-    * `fg.utils.get_rotpole` now accept more general inputs. (:pull:`308`).
+Fixes
+^^^^^
+* `fg.utils.get_rotpole` now accept more general inputs. (:pull:`308`).
 
 .. _changes_0.4.0:
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,7 +24,6 @@ dependencies:
   - blackdoc ==0.3.9
   - bump-my-version >=1.0.0
   - coverage >=7.5.0
-  - coveralls >=4.0.1
   - flake8 >=7.1.1
   - flake8-rst-docstrings >=0.3.0
   - flit >=3.10.1,<4.0.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,41 +1,34 @@
 name: figanos
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - python>=3.10,<3.13
+  - python>=3.10,<3.14
   # Main
   - cartopy >=0.23.0
   - cairosvg >=2.6.0
   - matplotlib-base >=3.6.0
   - seaborn >=0.13.0
   - geopandas >=1.0
-  - numpy >=1.23.0,<2.0.0
+  - numpy >=1.25.0
   - pandas >=2.2.0
   - platformdirs >=4.0
-  - pint >=0.10
+  - pint >=0.18
   - pyyaml >=6.0.1
-  - scikit-image >=0.20.0
-  - xarray >=2022.6.0
+  - scikit-image >=0.21.0
+  - xarray >=2023.11.0
   - xclim >=0.52.2
-  # To make the package and notebooks usable
-  - dask
-  - geoviews
-  - h5py
-  - holoviews
-  - netcdf4
-  - pooch >=1.8.0  # for xclim-testdata
-  - zarr >=2.13.0
   # Development
-  - pip >=24.3.1
+  - pip >=25.1
   - black ==25.1.0
   - blackdoc ==0.3.9
-  - bump-my-version >=0.30.1
+  - bump-my-version >=1.0.0
   - coverage >=7.5.0
   - coveralls >=4.0.1
   - flake8 >=7.1.1
   - flake8-rst-docstrings >=0.3.0
   - flit >=3.10.1,<4.0.0
-  - isort ==6.0.0
+  - isort ==6.0.1
   - mypy >=1.14.1
   - numpydoc >=1.8.0
   - pre-commit >=3.5.0
@@ -44,6 +37,14 @@ dependencies:
   - ruff >=0.9.0
   - tox >=4.24.1
   - watchdog >=4.0.0
+  # Notebooks
+  - dask
+  - geoviews
+  - h5py
+  - holoviews
+  - netcdf4
+  - pooch >=1.8.0  # for xclim-testdata
+  - zarr >=2.13.0
   # Docs
   - ipykernel
   - ipython >=8.5.0, !=9.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dev = [
   "blackdoc ==0.3.9",
   "bump-my-version >=1.0.0",
   "coverage >=7.5.0",
-  "coveralls >=4.0.1",
   "flake8 >=7.1.1",
   "flake8-rst-docstrings >=0.3.0",
   "flit >=3.10.1,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
   {name = "Trevor James Smith", email = "smith.trevorj@ouranos.ca"}
 ]
 readme = {file = "README.rst", content-type = "text/x-rst"}
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 keywords = ["figanos"]
 license = {file = "LICENSE"}
 classifiers = [
@@ -26,11 +26,10 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  # "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
 dynamic = ["description", "version"]
@@ -39,14 +38,14 @@ dependencies = [
   "cairosvg >=2.6.0",
   "geopandas >=1.0",
   "matplotlib >=3.6.0",
-  "numpy >=1.23.0,<2.0.0",
+  "numpy >=1.25.0",
   "pandas >=2.2.0",
-  "pint >=0.10",
+  "pint >=0.18",
   "platformdirs >=4.0",
   "pyyaml >=6.0.1",
   "seaborn >=0.13.0",
-  "scikit-image >=0.20.0",
-  "xarray >=2022.6.0",
+  "scikit-image >=0.21.0",
+  "xarray >=2023.11.0",
   "xclim >=0.52.2"
 ]
 
@@ -55,16 +54,16 @@ dev = [
   # Dev tools and testing
   "black ==25.1.0",
   "blackdoc ==0.3.9",
-  "bump-my-version >=0.30.1",
+  "bump-my-version >=1.0.0",
   "coverage >=7.5.0",
   "coveralls >=4.0.1",
-  "flake8 >=7.1.0",
+  "flake8 >=7.1.1",
   "flake8-rst-docstrings >=0.3.0",
   "flit >=3.10.1,<4.0",
   "isort ==6.0.1",
   "mypy >=1.14.1",
   "numpydoc >=1.8.0",
-  "pip >=24.3.1",
+  "pip >=25.1",
   "pre-commit >=3.5.0",
   "pytest >=8.3.2",
   "pytest-cov >=5.0.0",
@@ -86,6 +85,7 @@ docs = [
   "ipython >=8.5.0,!=9.0.0",
   "jupyter_client",
   "nbsphinx >=0.9.5",
+  "notebook",
   "sphinx >=7.0.0,<8.2.0", # pinned until nbsphinx is updated to support Sphinx 8.2
   "sphinx-book-theme >=1.0",
   "sphinx-codeautolink",
@@ -105,7 +105,6 @@ all = ["figanos[dev]", "figanos[docs]"]
 
 [tool.black]
 target-version = [
-  "py39",
   "py310",
   "py311",
   "py312",

--- a/src/figanos/_testing.py
+++ b/src/figanos/_testing.py
@@ -1,5 +1,6 @@
 from functools import wraps
-from typing import IO, Callable, Optional, Union
+from typing import IO, Optional, Union
+from collections.abc import Callable
 
 __all__ = ["pitou"]
 
@@ -32,12 +33,12 @@ def pitou():
 
     # Overload the fetch method to add user-agent headers
     @wraps(_pitou.fetch_diversion)
-    def _fetch(*args: str, **kwargs: Union[bool, Callable]) -> str:
+    def _fetch(*args: str, **kwargs: bool | Callable) -> str:
         def _downloader(
             url: str,
-            output_file: Union[str, IO],
+            output_file: str | IO,
             poocher: pooch.Pooch,
-            check_only: Optional[bool] = False,
+            check_only: bool | None = False,
         ) -> None:
             """Download the file from the URL and save it to the save_path."""
             headers = {"User-Agent": f"figanos ({__figanos_version__})"}

--- a/src/figanos/_testing.py
+++ b/src/figanos/_testing.py
@@ -1,6 +1,6 @@
-from functools import wraps
-from typing import IO, Optional, Union
 from collections.abc import Callable
+from functools import wraps
+from typing import IO
 
 __all__ = ["pitou"]
 

--- a/src/figanos/matplotlib/utils.py
+++ b/src/figanos/matplotlib/utils.py
@@ -9,7 +9,8 @@ import re
 import warnings
 from copy import deepcopy
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import cairosvg
 import cartopy.crs as ccrs

--- a/src/figanos/matplotlib/utils.py
+++ b/src/figanos/matplotlib/utils.py
@@ -7,10 +7,10 @@ import math
 import pathlib
 import re
 import warnings
+from collections.abc import Callable
 from copy import deepcopy
 from tempfile import NamedTemporaryFile
 from typing import Any
-from collections.abc import Callable
 
 import cairosvg
 import cartopy.crs as ccrs

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,31 @@
 [tox]
-min_version = 4.23.2
+min_version = 4.24.1
 envlist =
     lint
-    py{39,310,311,312,313}
+    py{310,311,312,313}
     docs
-    coveralls
+    coverage
 requires =
-    flit >= 3.9.0,<4.0
+    flit >= 3.10.1,<4.0
     pip >= 24.3.1
 opts =
      --verbose
 
 [gh]
 python =
-    3.9 = py39-coveralls
-    3.10 = py310-coveralls
-    3.11 = py311-coveralls
-    3.12 = py312-coveralls
+    3.10 = py310-coverage
+    3.11 = py311-coverage
+    3.12 = py312-coverage
     3.13 = py313 # FIXME: no coveralls until supported
 
 [testenv:lint]
 skip_install = True
 deps =
-    black[jupyter] ==24.10.0
+    black[jupyter] ==25.1.0
     blackdoc ==0.3.9
-    isort ==5.13.2
+    isort ==6.0.1
     flake8 >=7.1.1
-    ruff >=0.8.2
+    ruff >=0.9.0
     numpydoc >=1.8.0
 commands =
     make lint
@@ -55,11 +54,11 @@ extras =
 download = True
 install_command = python -m pip install --no-user {opts} {packages}
 deps =
-    coveralls: coveralls>=4.0.1
+    coverage: coveralls>=4.0.1
 commands_pre =
     pip list
     pip check
 commands =
     pytest --cov figanos
     ; Coveralls requires access to a repo token set in .coveralls.yml in order to report stats
-    coveralls: - coveralls
+    coverage: - coveralls


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Drops Python3.9, enables Python3.13
* Updates several dependency pins
* Adjusts the CI to the new configurations

### Does this PR introduce a breaking change?

Yes. Python 3.9 is no longer supported (reaching EoL date in a few months). Some base dependency pins are higher.

### Other information:

`figanos` is the only package in PAVICS that requires `numpy<2.0.0`. This change should move us up for the next user images.