### PR TITLE
use vmin and vmax with divergent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Fixes
 ^^^^^
 * The `categorical_colors.json` file has been fixed to have the RGB values of IPCC (:pull:`324`, :issue:`239`).
 * Fix cbar argument of ``gdfmap`` (:pull:`332`, :issue:`332`).
+* Allow vmin and vmax to be used with divergent (:pull:`342`).
 
 .. _changes_0.5.0:
 

--- a/src/figanos/matplotlib/plot.py
+++ b/src/figanos/matplotlib/plot.py
@@ -1853,7 +1853,7 @@ def scattermap(
         plot_kw.setdefault("edgecolors", "none")
 
     for key in ["vmin", "vmax"]:
-        plot_kw.pop(key)
+        plot_kw.pop(key, None)
     # plot
     plot_kw = {"x": "lon", "y": "lat", "hue": plot_data.name} | plot_kw
     if ax:

--- a/src/figanos/matplotlib/plot.py
+++ b/src/figanos/matplotlib/plot.py
@@ -715,10 +715,12 @@ def gridmap(
         plot_kw.setdefault("levels", lin)
 
     elif (divergent is not False) and ("levels" not in plot_kw):
+        vmin = plot_kw.pop("vmin", np.nanmin(plot_data.values))
+        vmax = plot_kw.pop("vmax", np.nanmax(plot_data.values))
         norm = custom_cmap_norm(
             cmap,
-            np.nanmin(plot_data.values),
-            np.nanmax(plot_data.values),
+            vmin,
+            vmax,
             levels=levels,
             divergent=divergent,
         )
@@ -765,6 +767,7 @@ def gridmap(
         plot_kw.setdefault("transform", transform)
 
     if contourf is False:
+        print(plot_kw)
         im = plot_data.plot.pcolormesh(**plot_kw)
     else:
         im = plot_data.plot.contourf(**plot_kw)
@@ -1806,10 +1809,12 @@ def scattermap(
         plot_kw.setdefault("levels", lin)
 
     elif (divergent is not False) and ("levels" not in plot_kw):
+        vmin = plot_kw.pop("vmin", np.nanmin(plot_data.values[mask]))
+        vmax = plot_kw.pop("vmax", np.nanmax(plot_data.values[mask]))
         norm = custom_cmap_norm(
             cmap,
-            np.nanmin(plot_data.values[mask]),
-            np.nanmax(plot_data.values[mask]),
+            vmin,
+            vmax,
             levels=levels,
             divergent=divergent,
         )

--- a/src/figanos/matplotlib/plot.py
+++ b/src/figanos/matplotlib/plot.py
@@ -767,7 +767,6 @@ def gridmap(
         plot_kw.setdefault("transform", transform)
 
     if contourf is False:
-        print(plot_kw)
         im = plot_data.plot.pcolormesh(**plot_kw)
     else:
         im = plot_data.plot.contourf(**plot_kw)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* If vmax and vmin are given, use them in creating the colormap (with divergent) instead of using the max and min of the data.

### Does this PR introduce a breaking change?
yes. This used to fail.

### Other information:
